### PR TITLE
Addition of os import into tauRAMD.py

### DIFF
--- a/tauRAMD.py
+++ b/tauRAMD.py
@@ -22,6 +22,7 @@ import seaborn as sns
 import numpy as np
 from scipy.stats import norm
 import sys
+import os
 
 
 soft = "Gr"    #   if Gromacs software was used for RAMD simulations;  otherwise define  soft = 'NAMD' 


### PR DESCRIPTION
Currently `tauRAMD.py` is missing the import of `os`, which the script uses during:

`else:`
`    for i in range(1,len(sys.argv)):`
`        if os.path.isfile(sys.argv[i]):`
`            print ("Data found:", sys.argv[i])`
`            d_list.append(sys.argv[i])`
`        else:`
`            print ("Data not found:", sys.argv[i])`

this leads to the error `NameError: name 'os' is not defined`

this PR adds the `import os` to cover this case